### PR TITLE
Adding missing @subsquid/logger runtime dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@subsquid/archive-registry": "^3.2.0",
         "@subsquid/evm-processor": "^1.4.0",
         "@subsquid/graphql-server": "^4.2.0",
+        "@subsquid/logger": "^1.3.0",
         "@subsquid/typeorm-migration": "^1.2.0",
         "@subsquid/typeorm-store": "^1.2.0",
         "dotenv": "^16.1.4",
@@ -1979,6 +1980,32 @@
         "squid-commands": "bin/run.js"
       }
     },
+    "node_modules/@subsquid/commands/node_modules/@subsquid/logger": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@subsquid/logger/-/logger-0.3.1.tgz",
+      "integrity": "sha512-Hi0aWeVgK0OZ3L2KxRejLCHIBIs6k3AR8FEb9RCKgQvqHK8DDNuMFANo4obHqXDZpDF+Ef+T050Oz5n4O1u3lA==",
+      "dev": true,
+      "dependencies": {
+        "@subsquid/util-internal-hex": "^0.0.2",
+        "@subsquid/util-internal-json": "^0.2.1",
+        "supports-color": "^8.1.1"
+      }
+    },
+    "node_modules/@subsquid/commands/node_modules/@subsquid/util-internal-hex": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-hex/-/util-internal-hex-0.0.2.tgz",
+      "integrity": "sha512-EgqYmZjJ6ox885tXBObEAZQZImpRc5pFzQeOLEh78gGPTc39IH3VI4BG0zaomStvgBx+e25M7Y2cc+ae+ttuXQ==",
+      "dev": true
+    },
+    "node_modules/@subsquid/commands/node_modules/@subsquid/util-internal-json": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-json/-/util-internal-json-0.2.1.tgz",
+      "integrity": "sha512-X9bhhKWBcaeZekGEiE15i8xwfq07/aIYDhA+JFdiVT3aygdb9b57V85USuArd6oh3jjHeQ2SBgj6B5rd8m8vlA==",
+      "dev": true,
+      "dependencies": {
+        "@subsquid/util-internal-hex": "^0.0.2"
+      }
+    },
     "node_modules/@subsquid/evm-processor": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/@subsquid/evm-processor/-/evm-processor-1.8.2.tgz",
@@ -1991,16 +2018,6 @@
         "@subsquid/util-internal-archive-client": "^0.0.0",
         "@subsquid/util-internal-hex": "^1.2.0",
         "@subsquid/util-internal-processor-tools": "^2.0.0"
-      }
-    },
-    "node_modules/@subsquid/evm-processor/node_modules/@subsquid/logger": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@subsquid/logger/-/logger-1.3.0.tgz",
-      "integrity": "sha512-1aCaFzGXrzW4bioiv6hPX+vsKO2EsiqFKcWedRW9G+0nnelAfhw5lGsyCvMzfkuk2xUCRA6vWwOReVK3BPW0Zg==",
-      "dependencies": {
-        "@subsquid/util-internal-hex": "^1.2.0",
-        "@subsquid/util-internal-json": "^1.2.0",
-        "supports-color": "^8.1.1"
       }
     },
     "node_modules/@subsquid/evm-processor/node_modules/@subsquid/util-internal": {
@@ -2026,14 +2043,6 @@
         }
       }
     },
-    "node_modules/@subsquid/evm-processor/node_modules/@subsquid/util-internal-json": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-json/-/util-internal-json-1.2.0.tgz",
-      "integrity": "sha512-r9DlJWs6GFF4uS486QTeBmmrMAFqUdSgOmx/HfxkOfEO/iSVaoh2n8FKKw0uQyCVmnsDvoz8v6COOovL4blZWA==",
-      "dependencies": {
-        "@subsquid/util-internal-hex": "^1.2.0"
-      }
-    },
     "node_modules/@subsquid/evm-typegen": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@subsquid/evm-typegen/-/evm-typegen-3.2.2.tgz",
@@ -2054,17 +2063,6 @@
         "ethers": "^6.6.5"
       }
     },
-    "node_modules/@subsquid/evm-typegen/node_modules/@subsquid/logger": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@subsquid/logger/-/logger-1.3.0.tgz",
-      "integrity": "sha512-1aCaFzGXrzW4bioiv6hPX+vsKO2EsiqFKcWedRW9G+0nnelAfhw5lGsyCvMzfkuk2xUCRA6vWwOReVK3BPW0Zg==",
-      "dev": true,
-      "dependencies": {
-        "@subsquid/util-internal-hex": "^1.2.0",
-        "@subsquid/util-internal-json": "^1.2.0",
-        "supports-color": "^8.1.1"
-      }
-    },
     "node_modules/@subsquid/evm-typegen/node_modules/@subsquid/util-internal": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-2.5.1.tgz",
@@ -2078,15 +2076,6 @@
       "dev": true,
       "peerDependencies": {
         "commander": "^11.0.0"
-      }
-    },
-    "node_modules/@subsquid/evm-typegen/node_modules/@subsquid/util-internal-json": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-json/-/util-internal-json-1.2.0.tgz",
-      "integrity": "sha512-r9DlJWs6GFF4uS486QTeBmmrMAFqUdSgOmx/HfxkOfEO/iSVaoh2n8FKKw0uQyCVmnsDvoz8v6COOovL4blZWA==",
-      "dev": true,
-      "dependencies": {
-        "@subsquid/util-internal-hex": "^1.2.0"
       }
     },
     "node_modules/@subsquid/evm-typegen/node_modules/commander": {
@@ -2156,16 +2145,6 @@
         }
       }
     },
-    "node_modules/@subsquid/graphql-server/node_modules/@subsquid/logger": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@subsquid/logger/-/logger-1.3.0.tgz",
-      "integrity": "sha512-1aCaFzGXrzW4bioiv6hPX+vsKO2EsiqFKcWedRW9G+0nnelAfhw5lGsyCvMzfkuk2xUCRA6vWwOReVK3BPW0Zg==",
-      "dependencies": {
-        "@subsquid/util-internal-hex": "^1.2.0",
-        "@subsquid/util-internal-json": "^1.2.0",
-        "supports-color": "^8.1.1"
-      }
-    },
     "node_modules/@subsquid/graphql-server/node_modules/@subsquid/util-internal": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-2.5.1.tgz",
@@ -2177,14 +2156,6 @@
       "integrity": "sha512-ZSPzYjNZ/k/6qDa7xdrCgXkq/whYnVPLF8nX+35aAgrM+ShX7XUg/Dq6u0rW3u3sfWcKzsNFHbFB8SzjWN5StA==",
       "peerDependencies": {
         "commander": "^11.0.0"
-      }
-    },
-    "node_modules/@subsquid/graphql-server/node_modules/@subsquid/util-internal-json": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-json/-/util-internal-json-1.2.0.tgz",
-      "integrity": "sha512-r9DlJWs6GFF4uS486QTeBmmrMAFqUdSgOmx/HfxkOfEO/iSVaoh2n8FKKw0uQyCVmnsDvoz8v6COOovL4blZWA==",
-      "dependencies": {
-        "@subsquid/util-internal-hex": "^1.2.0"
       }
     },
     "node_modules/@subsquid/graphql-server/node_modules/commander": {
@@ -2205,28 +2176,10 @@
         "node-fetch": "^3.3.1"
       }
     },
-    "node_modules/@subsquid/http-client/node_modules/@subsquid/logger": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@subsquid/logger/-/logger-1.3.0.tgz",
-      "integrity": "sha512-1aCaFzGXrzW4bioiv6hPX+vsKO2EsiqFKcWedRW9G+0nnelAfhw5lGsyCvMzfkuk2xUCRA6vWwOReVK3BPW0Zg==",
-      "dependencies": {
-        "@subsquid/util-internal-hex": "^1.2.0",
-        "@subsquid/util-internal-json": "^1.2.0",
-        "supports-color": "^8.1.1"
-      }
-    },
     "node_modules/@subsquid/http-client/node_modules/@subsquid/util-internal": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-2.5.1.tgz",
       "integrity": "sha512-URBBCWP/cXuNhFP8B5Qsm6qaft1CIoWRhx8mCL1gDxasLWmPEnLC2eMHfMvU0CtF9mYKyXV2SjCf4BK9tQJ92g=="
-    },
-    "node_modules/@subsquid/http-client/node_modules/@subsquid/util-internal-json": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-json/-/util-internal-json-1.2.0.tgz",
-      "integrity": "sha512-r9DlJWs6GFF4uS486QTeBmmrMAFqUdSgOmx/HfxkOfEO/iSVaoh2n8FKKw0uQyCVmnsDvoz8v6COOovL4blZWA==",
-      "dependencies": {
-        "@subsquid/util-internal-hex": "^1.2.0"
-      }
     },
     "node_modules/@subsquid/http-client/node_modules/node-fetch": {
       "version": "3.3.2",
@@ -2246,21 +2199,14 @@
       }
     },
     "node_modules/@subsquid/logger": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@subsquid/logger/-/logger-0.3.1.tgz",
-      "integrity": "sha512-Hi0aWeVgK0OZ3L2KxRejLCHIBIs6k3AR8FEb9RCKgQvqHK8DDNuMFANo4obHqXDZpDF+Ef+T050Oz5n4O1u3lA==",
-      "dev": true,
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/logger/-/logger-1.3.0.tgz",
+      "integrity": "sha512-1aCaFzGXrzW4bioiv6hPX+vsKO2EsiqFKcWedRW9G+0nnelAfhw5lGsyCvMzfkuk2xUCRA6vWwOReVK3BPW0Zg==",
       "dependencies": {
-        "@subsquid/util-internal-hex": "^0.0.2",
-        "@subsquid/util-internal-json": "^0.2.1",
+        "@subsquid/util-internal-hex": "^1.2.0",
+        "@subsquid/util-internal-json": "^1.2.0",
         "supports-color": "^8.1.1"
       }
-    },
-    "node_modules/@subsquid/logger/node_modules/@subsquid/util-internal-hex": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-hex/-/util-internal-hex-0.0.2.tgz",
-      "integrity": "sha512-EgqYmZjJ6ox885tXBObEAZQZImpRc5pFzQeOLEh78gGPTc39IH3VI4BG0zaomStvgBx+e25M7Y2cc+ae+ttuXQ==",
-      "dev": true
     },
     "node_modules/@subsquid/openreader": {
       "version": "4.4.0",
@@ -2298,16 +2244,6 @@
         }
       }
     },
-    "node_modules/@subsquid/openreader/node_modules/@subsquid/logger": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@subsquid/logger/-/logger-1.3.0.tgz",
-      "integrity": "sha512-1aCaFzGXrzW4bioiv6hPX+vsKO2EsiqFKcWedRW9G+0nnelAfhw5lGsyCvMzfkuk2xUCRA6vWwOReVK3BPW0Zg==",
-      "dependencies": {
-        "@subsquid/util-internal-hex": "^1.2.0",
-        "@subsquid/util-internal-json": "^1.2.0",
-        "supports-color": "^8.1.1"
-      }
-    },
     "node_modules/@subsquid/openreader/node_modules/@subsquid/util-internal": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-2.5.1.tgz",
@@ -2319,14 +2255,6 @@
       "integrity": "sha512-ZSPzYjNZ/k/6qDa7xdrCgXkq/whYnVPLF8nX+35aAgrM+ShX7XUg/Dq6u0rW3u3sfWcKzsNFHbFB8SzjWN5StA==",
       "peerDependencies": {
         "commander": "^11.0.0"
-      }
-    },
-    "node_modules/@subsquid/openreader/node_modules/@subsquid/util-internal-json": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-json/-/util-internal-json-1.2.0.tgz",
-      "integrity": "sha512-r9DlJWs6GFF4uS486QTeBmmrMAFqUdSgOmx/HfxkOfEO/iSVaoh2n8FKKw0uQyCVmnsDvoz8v6COOovL4blZWA==",
-      "dependencies": {
-        "@subsquid/util-internal-hex": "^1.2.0"
       }
     },
     "node_modules/@subsquid/openreader/node_modules/commander": {
@@ -2350,28 +2278,10 @@
         "websocket": "^1.0.34"
       }
     },
-    "node_modules/@subsquid/rpc-client/node_modules/@subsquid/logger": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@subsquid/logger/-/logger-1.3.0.tgz",
-      "integrity": "sha512-1aCaFzGXrzW4bioiv6hPX+vsKO2EsiqFKcWedRW9G+0nnelAfhw5lGsyCvMzfkuk2xUCRA6vWwOReVK3BPW0Zg==",
-      "dependencies": {
-        "@subsquid/util-internal-hex": "^1.2.0",
-        "@subsquid/util-internal-json": "^1.2.0",
-        "supports-color": "^8.1.1"
-      }
-    },
     "node_modules/@subsquid/rpc-client/node_modules/@subsquid/util-internal": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-2.5.1.tgz",
       "integrity": "sha512-URBBCWP/cXuNhFP8B5Qsm6qaft1CIoWRhx8mCL1gDxasLWmPEnLC2eMHfMvU0CtF9mYKyXV2SjCf4BK9tQJ92g=="
-    },
-    "node_modules/@subsquid/rpc-client/node_modules/@subsquid/util-internal-json": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-json/-/util-internal-json-1.2.0.tgz",
-      "integrity": "sha512-r9DlJWs6GFF4uS486QTeBmmrMAFqUdSgOmx/HfxkOfEO/iSVaoh2n8FKKw0uQyCVmnsDvoz8v6COOovL4blZWA==",
-      "dependencies": {
-        "@subsquid/util-internal-hex": "^1.2.0"
-      }
     },
     "node_modules/@subsquid/typeorm-codegen": {
       "version": "1.3.1",
@@ -2516,19 +2426,12 @@
       }
     },
     "node_modules/@subsquid/util-internal-json": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-json/-/util-internal-json-0.2.1.tgz",
-      "integrity": "sha512-X9bhhKWBcaeZekGEiE15i8xwfq07/aIYDhA+JFdiVT3aygdb9b57V85USuArd6oh3jjHeQ2SBgj6B5rd8m8vlA==",
-      "dev": true,
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-json/-/util-internal-json-1.2.0.tgz",
+      "integrity": "sha512-r9DlJWs6GFF4uS486QTeBmmrMAFqUdSgOmx/HfxkOfEO/iSVaoh2n8FKKw0uQyCVmnsDvoz8v6COOovL4blZWA==",
       "dependencies": {
-        "@subsquid/util-internal-hex": "^0.0.2"
+        "@subsquid/util-internal-hex": "^1.2.0"
       }
-    },
-    "node_modules/@subsquid/util-internal-json/node_modules/@subsquid/util-internal-hex": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-hex/-/util-internal-hex-0.0.2.tgz",
-      "integrity": "sha512-EgqYmZjJ6ox885tXBObEAZQZImpRc5pFzQeOLEh78gGPTc39IH3VI4BG0zaomStvgBx+e25M7Y2cc+ae+ttuXQ==",
-      "dev": true
     },
     "node_modules/@subsquid/util-internal-processor-tools": {
       "version": "2.0.0",
@@ -2543,28 +2446,10 @@
         "prom-client": "^14.2.0"
       }
     },
-    "node_modules/@subsquid/util-internal-processor-tools/node_modules/@subsquid/logger": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@subsquid/logger/-/logger-1.3.0.tgz",
-      "integrity": "sha512-1aCaFzGXrzW4bioiv6hPX+vsKO2EsiqFKcWedRW9G+0nnelAfhw5lGsyCvMzfkuk2xUCRA6vWwOReVK3BPW0Zg==",
-      "dependencies": {
-        "@subsquid/util-internal-hex": "^1.2.0",
-        "@subsquid/util-internal-json": "^1.2.0",
-        "supports-color": "^8.1.1"
-      }
-    },
     "node_modules/@subsquid/util-internal-processor-tools/node_modules/@subsquid/util-internal": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-2.5.1.tgz",
       "integrity": "sha512-URBBCWP/cXuNhFP8B5Qsm6qaft1CIoWRhx8mCL1gDxasLWmPEnLC2eMHfMvU0CtF9mYKyXV2SjCf4BK9tQJ92g=="
-    },
-    "node_modules/@subsquid/util-internal-processor-tools/node_modules/@subsquid/util-internal-json": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-json/-/util-internal-json-1.2.0.tgz",
-      "integrity": "sha512-r9DlJWs6GFF4uS486QTeBmmrMAFqUdSgOmx/HfxkOfEO/iSVaoh2n8FKKw0uQyCVmnsDvoz8v6COOovL4blZWA==",
-      "dependencies": {
-        "@subsquid/util-internal-hex": "^1.2.0"
-      }
     },
     "node_modules/@subsquid/util-internal-prometheus-server": {
       "version": "1.2.0",
@@ -16110,6 +15995,34 @@
         "@subsquid/util-internal-config": "^1.0.1",
         "glob": "^8.1.0",
         "supports-color": "^8.1.1"
+      },
+      "dependencies": {
+        "@subsquid/logger": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/@subsquid/logger/-/logger-0.3.1.tgz",
+          "integrity": "sha512-Hi0aWeVgK0OZ3L2KxRejLCHIBIs6k3AR8FEb9RCKgQvqHK8DDNuMFANo4obHqXDZpDF+Ef+T050Oz5n4O1u3lA==",
+          "dev": true,
+          "requires": {
+            "@subsquid/util-internal-hex": "^0.0.2",
+            "@subsquid/util-internal-json": "^0.2.1",
+            "supports-color": "^8.1.1"
+          }
+        },
+        "@subsquid/util-internal-hex": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/@subsquid/util-internal-hex/-/util-internal-hex-0.0.2.tgz",
+          "integrity": "sha512-EgqYmZjJ6ox885tXBObEAZQZImpRc5pFzQeOLEh78gGPTc39IH3VI4BG0zaomStvgBx+e25M7Y2cc+ae+ttuXQ==",
+          "dev": true
+        },
+        "@subsquid/util-internal-json": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/@subsquid/util-internal-json/-/util-internal-json-0.2.1.tgz",
+          "integrity": "sha512-X9bhhKWBcaeZekGEiE15i8xwfq07/aIYDhA+JFdiVT3aygdb9b57V85USuArd6oh3jjHeQ2SBgj6B5rd8m8vlA==",
+          "dev": true,
+          "requires": {
+            "@subsquid/util-internal-hex": "^0.0.2"
+          }
+        }
       }
     },
     "@subsquid/evm-processor": {
@@ -16126,16 +16039,6 @@
         "@subsquid/util-internal-processor-tools": "^2.0.0"
       },
       "dependencies": {
-        "@subsquid/logger": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@subsquid/logger/-/logger-1.3.0.tgz",
-          "integrity": "sha512-1aCaFzGXrzW4bioiv6hPX+vsKO2EsiqFKcWedRW9G+0nnelAfhw5lGsyCvMzfkuk2xUCRA6vWwOReVK3BPW0Zg==",
-          "requires": {
-            "@subsquid/util-internal-hex": "^1.2.0",
-            "@subsquid/util-internal-json": "^1.2.0",
-            "supports-color": "^8.1.1"
-          }
-        },
         "@subsquid/util-internal": {
           "version": "2.5.1",
           "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-2.5.1.tgz",
@@ -16149,14 +16052,6 @@
             "@subsquid/http-client": "^1.3.0",
             "@subsquid/util-internal": "^2.5.1",
             "@subsquid/util-internal-range": "^0.0.0"
-          }
-        },
-        "@subsquid/util-internal-json": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@subsquid/util-internal-json/-/util-internal-json-1.2.0.tgz",
-          "integrity": "sha512-r9DlJWs6GFF4uS486QTeBmmrMAFqUdSgOmx/HfxkOfEO/iSVaoh2n8FKKw0uQyCVmnsDvoz8v6COOovL4blZWA==",
-          "requires": {
-            "@subsquid/util-internal-hex": "^1.2.0"
           }
         }
       }
@@ -16175,17 +16070,6 @@
         "commander": "^11.0.0"
       },
       "dependencies": {
-        "@subsquid/logger": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@subsquid/logger/-/logger-1.3.0.tgz",
-          "integrity": "sha512-1aCaFzGXrzW4bioiv6hPX+vsKO2EsiqFKcWedRW9G+0nnelAfhw5lGsyCvMzfkuk2xUCRA6vWwOReVK3BPW0Zg==",
-          "dev": true,
-          "requires": {
-            "@subsquid/util-internal-hex": "^1.2.0",
-            "@subsquid/util-internal-json": "^1.2.0",
-            "supports-color": "^8.1.1"
-          }
-        },
         "@subsquid/util-internal": {
           "version": "2.5.1",
           "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-2.5.1.tgz",
@@ -16198,15 +16082,6 @@
           "integrity": "sha512-ZSPzYjNZ/k/6qDa7xdrCgXkq/whYnVPLF8nX+35aAgrM+ShX7XUg/Dq6u0rW3u3sfWcKzsNFHbFB8SzjWN5StA==",
           "dev": true,
           "requires": {}
-        },
-        "@subsquid/util-internal-json": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@subsquid/util-internal-json/-/util-internal-json-1.2.0.tgz",
-          "integrity": "sha512-r9DlJWs6GFF4uS486QTeBmmrMAFqUdSgOmx/HfxkOfEO/iSVaoh2n8FKKw0uQyCVmnsDvoz8v6COOovL4blZWA==",
-          "dev": true,
-          "requires": {
-            "@subsquid/util-internal-hex": "^1.2.0"
-          }
         },
         "commander": {
           "version": "11.0.0",
@@ -16251,16 +16126,6 @@
         "ws": "^8.13.0"
       },
       "dependencies": {
-        "@subsquid/logger": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@subsquid/logger/-/logger-1.3.0.tgz",
-          "integrity": "sha512-1aCaFzGXrzW4bioiv6hPX+vsKO2EsiqFKcWedRW9G+0nnelAfhw5lGsyCvMzfkuk2xUCRA6vWwOReVK3BPW0Zg==",
-          "requires": {
-            "@subsquid/util-internal-hex": "^1.2.0",
-            "@subsquid/util-internal-json": "^1.2.0",
-            "supports-color": "^8.1.1"
-          }
-        },
         "@subsquid/util-internal": {
           "version": "2.5.1",
           "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-2.5.1.tgz",
@@ -16271,14 +16136,6 @@
           "resolved": "https://registry.npmjs.org/@subsquid/util-internal-commander/-/util-internal-commander-1.3.0.tgz",
           "integrity": "sha512-ZSPzYjNZ/k/6qDa7xdrCgXkq/whYnVPLF8nX+35aAgrM+ShX7XUg/Dq6u0rW3u3sfWcKzsNFHbFB8SzjWN5StA==",
           "requires": {}
-        },
-        "@subsquid/util-internal-json": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@subsquid/util-internal-json/-/util-internal-json-1.2.0.tgz",
-          "integrity": "sha512-r9DlJWs6GFF4uS486QTeBmmrMAFqUdSgOmx/HfxkOfEO/iSVaoh2n8FKKw0uQyCVmnsDvoz8v6COOovL4blZWA==",
-          "requires": {
-            "@subsquid/util-internal-hex": "^1.2.0"
-          }
         },
         "commander": {
           "version": "11.0.0",
@@ -16297,28 +16154,10 @@
         "node-fetch": "^3.3.1"
       },
       "dependencies": {
-        "@subsquid/logger": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@subsquid/logger/-/logger-1.3.0.tgz",
-          "integrity": "sha512-1aCaFzGXrzW4bioiv6hPX+vsKO2EsiqFKcWedRW9G+0nnelAfhw5lGsyCvMzfkuk2xUCRA6vWwOReVK3BPW0Zg==",
-          "requires": {
-            "@subsquid/util-internal-hex": "^1.2.0",
-            "@subsquid/util-internal-json": "^1.2.0",
-            "supports-color": "^8.1.1"
-          }
-        },
         "@subsquid/util-internal": {
           "version": "2.5.1",
           "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-2.5.1.tgz",
           "integrity": "sha512-URBBCWP/cXuNhFP8B5Qsm6qaft1CIoWRhx8mCL1gDxasLWmPEnLC2eMHfMvU0CtF9mYKyXV2SjCf4BK9tQJ92g=="
-        },
-        "@subsquid/util-internal-json": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@subsquid/util-internal-json/-/util-internal-json-1.2.0.tgz",
-          "integrity": "sha512-r9DlJWs6GFF4uS486QTeBmmrMAFqUdSgOmx/HfxkOfEO/iSVaoh2n8FKKw0uQyCVmnsDvoz8v6COOovL4blZWA==",
-          "requires": {
-            "@subsquid/util-internal-hex": "^1.2.0"
-          }
         },
         "node-fetch": {
           "version": "3.3.2",
@@ -16333,22 +16172,13 @@
       }
     },
     "@subsquid/logger": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@subsquid/logger/-/logger-0.3.1.tgz",
-      "integrity": "sha512-Hi0aWeVgK0OZ3L2KxRejLCHIBIs6k3AR8FEb9RCKgQvqHK8DDNuMFANo4obHqXDZpDF+Ef+T050Oz5n4O1u3lA==",
-      "dev": true,
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/logger/-/logger-1.3.0.tgz",
+      "integrity": "sha512-1aCaFzGXrzW4bioiv6hPX+vsKO2EsiqFKcWedRW9G+0nnelAfhw5lGsyCvMzfkuk2xUCRA6vWwOReVK3BPW0Zg==",
       "requires": {
-        "@subsquid/util-internal-hex": "^0.0.2",
-        "@subsquid/util-internal-json": "^0.2.1",
+        "@subsquid/util-internal-hex": "^1.2.0",
+        "@subsquid/util-internal-json": "^1.2.0",
         "supports-color": "^8.1.1"
-      },
-      "dependencies": {
-        "@subsquid/util-internal-hex": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/@subsquid/util-internal-hex/-/util-internal-hex-0.0.2.tgz",
-          "integrity": "sha512-EgqYmZjJ6ox885tXBObEAZQZImpRc5pFzQeOLEh78gGPTc39IH3VI4BG0zaomStvgBx+e25M7Y2cc+ae+ttuXQ==",
-          "dev": true
-        }
       }
     },
     "@subsquid/openreader": {
@@ -16376,16 +16206,6 @@
         "ws": "^8.13.0"
       },
       "dependencies": {
-        "@subsquid/logger": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@subsquid/logger/-/logger-1.3.0.tgz",
-          "integrity": "sha512-1aCaFzGXrzW4bioiv6hPX+vsKO2EsiqFKcWedRW9G+0nnelAfhw5lGsyCvMzfkuk2xUCRA6vWwOReVK3BPW0Zg==",
-          "requires": {
-            "@subsquid/util-internal-hex": "^1.2.0",
-            "@subsquid/util-internal-json": "^1.2.0",
-            "supports-color": "^8.1.1"
-          }
-        },
         "@subsquid/util-internal": {
           "version": "2.5.1",
           "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-2.5.1.tgz",
@@ -16396,14 +16216,6 @@
           "resolved": "https://registry.npmjs.org/@subsquid/util-internal-commander/-/util-internal-commander-1.3.0.tgz",
           "integrity": "sha512-ZSPzYjNZ/k/6qDa7xdrCgXkq/whYnVPLF8nX+35aAgrM+ShX7XUg/Dq6u0rW3u3sfWcKzsNFHbFB8SzjWN5StA==",
           "requires": {}
-        },
-        "@subsquid/util-internal-json": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@subsquid/util-internal-json/-/util-internal-json-1.2.0.tgz",
-          "integrity": "sha512-r9DlJWs6GFF4uS486QTeBmmrMAFqUdSgOmx/HfxkOfEO/iSVaoh2n8FKKw0uQyCVmnsDvoz8v6COOovL4blZWA==",
-          "requires": {
-            "@subsquid/util-internal-hex": "^1.2.0"
-          }
         },
         "commander": {
           "version": "11.0.0",
@@ -16425,28 +16237,10 @@
         "websocket": "^1.0.34"
       },
       "dependencies": {
-        "@subsquid/logger": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@subsquid/logger/-/logger-1.3.0.tgz",
-          "integrity": "sha512-1aCaFzGXrzW4bioiv6hPX+vsKO2EsiqFKcWedRW9G+0nnelAfhw5lGsyCvMzfkuk2xUCRA6vWwOReVK3BPW0Zg==",
-          "requires": {
-            "@subsquid/util-internal-hex": "^1.2.0",
-            "@subsquid/util-internal-json": "^1.2.0",
-            "supports-color": "^8.1.1"
-          }
-        },
         "@subsquid/util-internal": {
           "version": "2.5.1",
           "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-2.5.1.tgz",
           "integrity": "sha512-URBBCWP/cXuNhFP8B5Qsm6qaft1CIoWRhx8mCL1gDxasLWmPEnLC2eMHfMvU0CtF9mYKyXV2SjCf4BK9tQJ92g=="
-        },
-        "@subsquid/util-internal-json": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@subsquid/util-internal-json/-/util-internal-json-1.2.0.tgz",
-          "integrity": "sha512-r9DlJWs6GFF4uS486QTeBmmrMAFqUdSgOmx/HfxkOfEO/iSVaoh2n8FKKw0uQyCVmnsDvoz8v6COOovL4blZWA==",
-          "requires": {
-            "@subsquid/util-internal-hex": "^1.2.0"
-          }
         }
       }
     },
@@ -16569,20 +16363,11 @@
       }
     },
     "@subsquid/util-internal-json": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-json/-/util-internal-json-0.2.1.tgz",
-      "integrity": "sha512-X9bhhKWBcaeZekGEiE15i8xwfq07/aIYDhA+JFdiVT3aygdb9b57V85USuArd6oh3jjHeQ2SBgj6B5rd8m8vlA==",
-      "dev": true,
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-json/-/util-internal-json-1.2.0.tgz",
+      "integrity": "sha512-r9DlJWs6GFF4uS486QTeBmmrMAFqUdSgOmx/HfxkOfEO/iSVaoh2n8FKKw0uQyCVmnsDvoz8v6COOovL4blZWA==",
       "requires": {
-        "@subsquid/util-internal-hex": "^0.0.2"
-      },
-      "dependencies": {
-        "@subsquid/util-internal-hex": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/@subsquid/util-internal-hex/-/util-internal-hex-0.0.2.tgz",
-          "integrity": "sha512-EgqYmZjJ6ox885tXBObEAZQZImpRc5pFzQeOLEh78gGPTc39IH3VI4BG0zaomStvgBx+e25M7Y2cc+ae+ttuXQ==",
-          "dev": true
-        }
+        "@subsquid/util-internal-hex": "^1.2.0"
       }
     },
     "@subsquid/util-internal-processor-tools": {
@@ -16598,28 +16383,10 @@
         "prom-client": "^14.2.0"
       },
       "dependencies": {
-        "@subsquid/logger": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@subsquid/logger/-/logger-1.3.0.tgz",
-          "integrity": "sha512-1aCaFzGXrzW4bioiv6hPX+vsKO2EsiqFKcWedRW9G+0nnelAfhw5lGsyCvMzfkuk2xUCRA6vWwOReVK3BPW0Zg==",
-          "requires": {
-            "@subsquid/util-internal-hex": "^1.2.0",
-            "@subsquid/util-internal-json": "^1.2.0",
-            "supports-color": "^8.1.1"
-          }
-        },
         "@subsquid/util-internal": {
           "version": "2.5.1",
           "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-2.5.1.tgz",
           "integrity": "sha512-URBBCWP/cXuNhFP8B5Qsm6qaft1CIoWRhx8mCL1gDxasLWmPEnLC2eMHfMvU0CtF9mYKyXV2SjCf4BK9tQJ92g=="
-        },
-        "@subsquid/util-internal-json": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@subsquid/util-internal-json/-/util-internal-json-1.2.0.tgz",
-          "integrity": "sha512-r9DlJWs6GFF4uS486QTeBmmrMAFqUdSgOmx/HfxkOfEO/iSVaoh2n8FKKw0uQyCVmnsDvoz8v6COOovL4blZWA==",
-          "requires": {
-            "@subsquid/util-internal-hex": "^1.2.0"
-          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@subsquid/archive-registry": "^3.2.0",
     "@subsquid/evm-processor": "^1.4.0",
     "@subsquid/graphql-server": "^4.2.0",
+    "@subsquid/logger": "^1.3.0",
     "@subsquid/typeorm-migration": "^1.2.0",
     "@subsquid/typeorm-store": "^1.2.0",
     "dotenv": "^16.1.4",


### PR DESCRIPTION
When I tried to build a docker image for local execution it complained about missing this dependency.
