### PR TITLE
Chore: Add issues config.

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+    - name: 🤔 Questions and Help
+      url: https://discord.gg/cartesi
+      about: This issue tracker is not for support questions. Please refer to the discord Cartesi Development Community server for help and discussion.


### PR DESCRIPTION
### Summary
Include issues config to give directions for `Questions and Help` pointing to our discord and blocking blank issues creation, so a template needs to be chosen. 


Nothing special is available on the explorer repo: https://github.com/cartesi/explorer/issues/new/choose