### PR TITLE
Fix local docker tag to match the one produced by CI

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,8 @@
     "editor.codeActionsOnSave": {
         "source.fixAll": true,
         "source.organizeImports": true
+    },
+    "[terraform]": {
+        "editor.defaultFormatter": "hashicorp.terraform"
     }
 }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -2,5 +2,5 @@ target "docker-metadata-action" {}
 target "docker-platforms" {}
 
 target "default" {
-    inherits = ["docker-metadata-action", "docker-platforms"]
+  inherits = ["docker-metadata-action", "docker-platforms"]
 }

--- a/docker-bake.override.hcl
+++ b/docker-bake.override.hcl
@@ -1,3 +1,3 @@
 target "default" {
-    tags = ["cartesi/rollups-subsquid:devel"]
+  tags = ["cartesi/rollups-explorer-api:devel"]
 }

--- a/docker-bake.platforms.hcl
+++ b/docker-bake.platforms.hcl
@@ -1,6 +1,6 @@
 target "docker-platforms" {
-    platforms = [
-        "linux/amd64",
-        "linux/arm64"
-    ]
+  platforms = [
+    "linux/amd64",
+    "linux/arm64"
+  ]
 }


### PR DESCRIPTION
Changes local docker tag from `cartesi/rollups-squid` to `cartesi/rollups-explorer-api`, as it is in the CI docker build.
Also format the code with the vscode terraform plugin.
