### PR TITLE
Feat: Add config to set RPC node based on chain id.

### DIFF
--- a/.env
+++ b/.env
@@ -4,4 +4,6 @@ GQL_PORT=4350
 # JSON-RPC node endpoint, both wss and https endpoints are accepted
 CHAIN_ID="11155111"
 # possible configurations
-# RPC_ENDPOINT=
+# RPC_URL_1=
+# RPC_URL_11155111=
+# RPC_URL_31337=

--- a/squid-mainnet.yaml
+++ b/squid-mainnet.yaml
@@ -6,10 +6,11 @@ build:
 deploy:
     addons:
         postgres:
+    secrets:
+        - RPC_URL_1
     processor:
         env:
             CHAIN_ID: 1
-            RPC_ENDPOINT: https://rpc.ankr.com/eth
         cmd:
             - node
             - lib/main

--- a/squid-sepolia.yaml
+++ b/squid-sepolia.yaml
@@ -6,10 +6,11 @@ build:
 deploy:
     addons:
         postgres:
+    secrets:
+        - RPC_URL_11155111
     processor:
         env:
             CHAIN_ID: 11155111
-            RPC_ENDPOINT: https://rpc.ankr.com/eth_sepolia
         cmd:
             - node
             - lib/main

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,13 +20,13 @@ export type ProcessorConfig = {
 };
 
 export const getConfig = (chainId: number): ProcessorConfig => {
+    const RPC_URL = `RPC_URL_${chainId}`;
     switch (chainId) {
         case 1: // mainnet
             return {
                 dataSource: {
                     archive: lookupArchive('eth-mainnet'),
-                    chain:
-                        process.env.RPC_ENDPOINT ?? 'https://rpc.ankr.com/eth',
+                    chain: process.env[RPC_URL] ?? 'https://rpc.ankr.com/eth',
                 },
                 from: Math.min(
                     CartesiDAppFactoryMainnet.receipt.blockNumber,
@@ -38,7 +38,7 @@ export const getConfig = (chainId: number): ProcessorConfig => {
                 dataSource: {
                     archive: lookupArchive('sepolia'),
                     chain:
-                        process.env.RPC_ENDPOINT ??
+                        process.env[RPC_URL] ??
                         'https://rpc.ankr.com/eth_sepolia',
                 },
                 from: Math.min(
@@ -49,7 +49,7 @@ export const getConfig = (chainId: number): ProcessorConfig => {
         case 31337: // anvil
             return {
                 dataSource: {
-                    chain: process.env.RPC_ENDPOINT ?? 'http://127.0.0.1:8545',
+                    chain: process.env[RPC_URL] ?? 'http://127.0.0.1:8545',
                 },
                 from: 0,
             };

--- a/tests/processor.test.ts
+++ b/tests/processor.test.ts
@@ -1,3 +1,4 @@
+import { afterEach } from 'node:test';
 import { MockInstance, beforeEach, describe, expect, test, vi } from 'vitest';
 import { createProcessor } from '../src/processor';
 
@@ -26,6 +27,10 @@ const local = 31337;
 describe('Processor creation', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        vi.unstubAllEnvs();
     });
 
     test('Throw error for unsupported chains', () => {
@@ -172,6 +177,41 @@ describe('Processor creation', () => {
                 '0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0',
             ],
             transaction: true,
+        });
+    });
+
+    test('Set correct chain for sepolia based on environment var', () => {
+        const myRPCNodeURL = 'https://my-custom-sepolia-node/v3/api';
+        vi.stubEnv('RPC_URL_11155111', myRPCNodeURL);
+
+        const processor = createProcessor(sepolia);
+
+        expect(processor.setDataSource).toHaveBeenCalledWith({
+            archive: 'https://v2.archive.subsquid.io/network/ethereum-sepolia',
+            chain: 'https://my-custom-sepolia-node/v3/api',
+        });
+    });
+
+    test('Set correct chain for mainnet based on environment var', () => {
+        const myRPCNodeURL = 'https://my-custom-mainnet-node/v3/api';
+        vi.stubEnv('RPC_URL_1', myRPCNodeURL);
+
+        const processor = createProcessor(mainnet);
+
+        expect(processor.setDataSource).toHaveBeenCalledWith({
+            archive: 'https://v2.archive.subsquid.io/network/ethereum-mainnet',
+            chain: 'https://my-custom-mainnet-node/v3/api',
+        });
+    });
+
+    test('Set correct chain for local/anvil based on environment var', () => {
+        const myRPCNodeURL = 'https://my-custom-local-node:9000';
+        vi.stubEnv('RPC_URL_31337', myRPCNodeURL);
+
+        const processor = createProcessor(local);
+
+        expect(processor.setDataSource).toHaveBeenCalledWith({
+            chain: 'https://my-custom-local-node:9000',
         });
     });
 });


### PR DESCRIPTION
### Summary
Code changes to support setup of paid RPC node based on chain id and switching to be a secret in the manifesto. 


Changes:
* Added changes in the config to set the chain in the data source configuration based in the environment variable `RPC_URL_${chainId}`. Fallback to ankr URLs. 
* Added test cases for each of the supported networks, i.e. [`1`, `11155111`, `31337`]