### PR TITLE
refactor: changing the branch ref for aquarium deployments.

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,8 +3,8 @@ on:
     push:
         branches:
             - main
-            - mainnet
-            - sepolia
+            - mainnet-aquarium
+            - sepolia-aquarium
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true
@@ -32,8 +32,8 @@ jobs:
             - name: Publish coveralls report
               uses: coverallsapp/github-action@master
               with:
-                path-to-lcov: 'coverage/lcov.info'
-                github-token: ${{ secrets.GITHUB_TOKEN }}
+                  path-to-lcov: 'coverage/lcov.info'
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Aquarium Login
               run: npm run sqd:auth
@@ -41,9 +41,9 @@ jobs:
                   SQD_API_KEY: ${{ secrets.SQD_API_KEY }}
 
             - name: Deploy sepolia
-              if: github.ref == 'refs/heads/sepolia'
+              if: github.ref == 'refs/heads/sepolia-aquarium'
               run: npm run sqd:deploy:sepolia -- --no-stream-logs --update
 
             - name: Deploy mainnet
-              if: github.ref == 'refs/heads/mainnet'
+              if: github.ref == 'refs/heads/mainnet-aquarium'
               run: npm run sqd:deploy:mainnet -- --no-stream-logs --update


### PR DESCRIPTION
### Summary
Code changes to separate deployment for aquarium. Currently, we are moving to Heroku as the main API, but Aquarium once stable in terms of infrastructure/deployments can be a good contingency.