### PR TITLE
Feature: Add timestamp field to the Application domain

### DIFF
--- a/db/migrations/1700532563386-Data.js
+++ b/db/migrations/1700532563386-Data.js
@@ -1,0 +1,11 @@
+module.exports = class Data1700532563386 {
+    name = 'Data1700532563386'
+
+    async up(db) {
+        await db.query(`ALTER TABLE "application" ADD "timestamp" numeric NOT NULL`)
+    }
+
+    async down(db) {
+        await db.query(`ALTER TABLE "application" DROP COLUMN "timestamp"`)
+    }
+}

--- a/schema.graphql
+++ b/schema.graphql
@@ -6,6 +6,7 @@ type ApplicationFactory @entity @cardinality(value: 5) {
 type Application @entity @cardinality(value: 100) {
     id: ID!
     owner: String
+    timestamp: BigInt!
     factory: ApplicationFactory
     inputs: [Input!] @derivedFrom(field: "application")
 }

--- a/src/handlers/ApplicationCreated.ts
+++ b/src/handlers/ApplicationCreated.ts
@@ -33,7 +33,9 @@ export default class ApplicationCreated implements Handler {
                 id,
                 factory,
                 owner: dappOwner.toLowerCase(),
+                timestamp: timestamp / 1000n,
             });
+
             this.applicationStorage.set(id, app);
             ctx.log.info(`${id} (Application) stored`);
         }

--- a/src/handlers/InputAdded.ts
+++ b/src/handlers/InputAdded.ts
@@ -55,13 +55,17 @@ export default class InputAdded implements Handler {
             const timestamp = BigInt(log.block.timestamp);
             const event = events.InputAdded.decode(log);
             const dappId = event.dapp.toLowerCase();
+            const timestampInSeconds = timestamp / 1000n;
 
             let application =
                 this.applicationStorage.get(dappId) ??
                 (await ctx.store.get(Application, dappId));
             if (!application) {
                 ctx.log.warn(`${dappId} (Application) not found`);
-                application = new Application({ id: dappId });
+                application = new Application({
+                    id: dappId,
+                    timestamp: timestampInSeconds,
+                });
                 this.applicationStorage.set(dappId, application);
                 ctx.log.info(`${dappId} (Application) stored`);
             }
@@ -73,7 +77,7 @@ export default class InputAdded implements Handler {
                 index: Number(event.inboxInputIndex),
                 msgSender: event.sender.toLowerCase(),
                 payload: event.input,
-                timestamp: timestamp / 1000n,
+                timestamp: timestampInSeconds,
                 blockNumber: BigInt(log.block.height),
                 blockHash: log.block.hash,
                 transactionHash: log.transaction?.hash,

--- a/tests/stubs/params.ts
+++ b/tests/stubs/params.ts
@@ -6,6 +6,7 @@ import {
     CartesiDAppFactoryAddress,
     ERC20PortalAddress,
 } from '../../src/config';
+import { Input } from '../../src/model';
 vi.mock('@subsquid/logger', async (importOriginal) => {
     const actualMods = await importOriginal;
     const Logger = vi.fn();
@@ -31,6 +32,7 @@ export const input = {
     id: '0x60a7048c3136293071605a4eaffef49923e981cc-0',
     application: {
         id: '0x60a7048c3136293071605a4eaffef49923e981cc',
+        timestamp: 1696281168n,
         owner: null,
         factory: null,
         inputs: [],
@@ -38,14 +40,14 @@ export const input = {
     index: 1,
     msgSender: ERC20PortalAddress,
     payload: payload,
-    timestamp: 1691384268 as unknown as bigint,
-    blockNumber: 4040941 as unknown as bigint,
+    timestamp: 1691384268n,
+    blockNumber: 4040941n,
     blockHash:
         '0xce6a0d404b4201b3bd4fb8309df0b6a64f6a5d7b71fa89bf2737d4574c58b32f',
     erc20Deposit: null,
     transactionHash:
         '0x6a3d76983453c0f74188bd89e01576c35f9d9b02daecdd49f7171aeb2bd3dc78',
-};
+} satisfies Input;
 
 export const logs = [
     {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,10 +1,11 @@
-import { defineConfig } from 'vitest/config'
 import { UserConfig } from 'vitest';
+import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
     test: {
         coverage: {
             reporter: ['text', 'lcov'],
+            exclude: ['src/abi', 'src/model', 'tests/'],
         },
     } as UserConfig,
-})
+});


### PR DESCRIPTION
### Summary

Code changes to support a piece of work to be done in the rollups-explorer frontend [New Home content](https://github.com/cartesi/rollups-explorer/issues/68). We want summaries in the Home, one being the `Latest x applications` widget. Hence, there is a need to have the time information to list the latest ones correctly.