### PR TITLE
fix: Archive node URL retrieve for Ethereum Sepolia.

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -42,7 +42,7 @@ export const getConfig = (chainId: number): ProcessorConfig => {
         case 11155111: // sepolia
             return {
                 dataSource: {
-                    archive: lookupArchive('sepolia'),
+                    archive: lookupArchive('eth-sepolia'),
                     chain:
                         process.env[RPC_URL] ??
                         'https://rpc.ankr.com/eth_sepolia',


### PR DESCRIPTION
### Summary
There was a silent breaking change in the source of information the `lookupArchive()` function uses to fetch the archive-node URL. The previous name was removed from the JSON provided by the following CDN, causing our processor to fail. Looking at the discord channel for the announcements and dev-support but could not find any info.

CDN: https://cdn.subsquid.io/archives/evm.json


**Just a comment/rant:** The processor and graphql-server run separately, so maybe people have not noticed yet, as one does not influence the other. That archive is "community managed," whatever that means, so it is a flaky point, and maybe some action would be necessary in the future to diminish the impacts of these unexpected changes.