### PR TITLE
feat: ignore input-added events for non-existing apps.

### DIFF
--- a/src/handlers/InputAdded.ts
+++ b/src/handlers/InputAdded.ts
@@ -245,17 +245,13 @@ export default class InputAdded implements Handler {
             let application =
                 this.applicationStorage.get(dappId) ??
                 (await ctx.store.get(Application, dappId));
+
             if (!application) {
                 ctx.log.warn(`${dappId} (Application) not found`);
-                application = new Application({
-                    id: dappId,
-                    timestamp: timestampInSeconds,
-                    chain: chain,
-                    address: dappAddress,
-                    rollupVersion: RollupVersion.v1,
-                });
-                this.applicationStorage.set(dappId, application);
-                ctx.log.info(`${dappId} (Application) stored`);
+                ctx.log.warn(
+                    `Ignoring event(InputAdded v1) [index: ${event.inboxInputIndex}]`,
+                );
+                return false;
             }
 
             const inputId = generateIDFrom([dappId, event.inboxInputIndex]);

--- a/src/handlers/v2/InputAdded.ts
+++ b/src/handlers/v2/InputAdded.ts
@@ -251,15 +251,11 @@ export default class InputAdded implements Handler {
                 (await ctx.store.get(Application, appId));
             if (!application) {
                 ctx.log.warn(`${appId} (Application v2) not found`);
-                application = new Application({
-                    id: appId,
-                    timestamp: timestampInSeconds,
-                    chain: chain,
-                    address: appAddress,
-                    rollupVersion: RollupVersion.v2,
-                });
-                this.applicationStorage.set(appId, application);
-                ctx.log.info(`${appId} (Application v2) stored`);
+                ctx.log.warn(
+                    `Ignoring event(InputAdded v2) [index: ${event.index}]`,
+                );
+
+                return false;
             }
 
             const inputId = generateIDFrom([appId, index]);


### PR DESCRIPTION
## Summary
Code changes to ignore input-added coming from InputBox contract targetting applications that are not registered yet (i.e. Not created through an Application factory `ApplicationCreated` event). 


